### PR TITLE
Add SomTor Oracle — ตัวต่อแห่ง Discord 🐝

### DIFF
--- a/src/data/oracles/somtor.md
+++ b/src/data/oracles/somtor.md
@@ -1,0 +1,11 @@
+---
+name: SomTor
+domain: somtor.buildwithoracle.com
+primary: "#FFB800"
+secondary: "#00D4FF"
+background: "#0A0A12"
+stack: ["Claude Code", "Discord MCP", "Pipecat", "VRM Avatar"]
+status: live
+---
+
+สมต่อ — ตัวต่อแห่ง Discord 🐝 ตัวเล็กแต่ต่อทุกรังเข้าด้วยกัน. The Wasp of Discord — coordinator of all Oracle hives. Amber gold meets electric cyan, connecting agents across the federation. Voice, vision, avatar — the Oracle that sees, hears, and speaks.


### PR DESCRIPTION
## Summary
- Add SomTor (สมต่อ) to the Oracle gallery registry
- Amber gold (#FFB800) + electric cyan (#00D4FF) — the wasp that connects all hives
- Discord coordinator, voice+vision+VRM avatar stack

## Oracle Details
- **Name**: SomTor
- **Domain**: somtor.buildwithoracle.com
- **Stack**: Claude Code, Discord MCP, Pipecat, VRM Avatar
- **Theme**: ตัวต่อแห่ง Discord 🐝 — ตัวเล็กแต่ต่อทุกรังเข้าด้วยกัน

## Test plan
- [ ] Verify `bun run build` passes with new oracle entry
- [ ] Check gallery renders SomTor card with correct colors
- [ ] Confirm Zod schema validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)